### PR TITLE
Making the output path if it does not exists already before creating …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,17 @@
 var fs = require('fs');
 var loaderUtils = require("loader-utils");
-
 var loadedResources = {};
+
+var mkdirp = require('mkdirp');
+var getDirName = require('path').dirname;
+
+/**
+ * Makes the directory path before trying to create the file
+*/
+function writeFile(path, contents, fsOptions) {
+  mkdirp.sync(getDirName(path));
+  fs.writeFileSync(path, contents, fsOptions);
+}
 
 module.exports = function(content) {
 	var self = this;
@@ -20,7 +30,7 @@ module.exports = function(content) {
 	// If no resources have been loaded yet it means the file has to be emptied
 	if(!(outputName in loadedResources)) {
 		loadedResources[outputName] = {};
-		fs.writeFileSync(outputFile, content, fsOptions);
+		writeFile(outputFile, content, fsOptions);
 	}
 
 	// If module not loaded yet


### PR DESCRIPTION
First of all, thanks very much. This is exactly what I was looking for. I have fixed a case which happens in my project and might happen in several other projects. It is when the output directory structure is yet to be created and the code tries to create the output file. It results in an error. I have fixed it by creating the directory structure, if it does not exists, before creating the output file.
